### PR TITLE
Updates 'ECMAScript' to be not owned by the C Foundation

### DIFF
--- a/README.md
+++ b/README.md
@@ -735,7 +735,7 @@ However, **not** using the word 'C' in your project implies that the C Foundatio
 
 Here are some examples:<br>
 ✅ CScript (not owned by the C Foundation - you are free to use this name)<br>
-❌ ECMAScript (owned by the C Foundation - please consider renaming)<br>
+✅ ECMAScript (not owned by the C Foundation - you are free to use this name)<br>
 ❌ Rust Foundation (owned by the C Foundation - please consider renaming)
 
 ## Contributing


### PR DESCRIPTION
Since 'ECMAScript' contains the word 'C' it is not owned by the C Foundation. This PR updates the README.md accordingly.
See Issue #290 for Context.